### PR TITLE
Make WebSocket address dynamic

### DIFF
--- a/webserver.cpp
+++ b/webserver.cpp
@@ -1,4 +1,5 @@
 #include "webserver.hpp"
+#include "json.hpp"
 
 WebServer::WebServer(unsigned short port, std::string content_dir)
     : port(port)
@@ -26,6 +27,13 @@ void WebServer::run()
     server = std::make_unique<httplib::Server>();
     server->set_mount_point("/", content_dir.c_str());
 
+     // Add config endpoint
+    server->Get("/config.json", [this](const httplib::Request&, httplib::Response& res) {
+        nlohmann::json config;
+        config["proxyPorts"] = proxy_ports; // will be a JSON object mapping names to ports
+        res.set_content(config.dump(), "application/json");
+    });
+
     log_info("HTTP server serving directory '%s' on port %u", content_dir.c_str(), port);
     server->listen("0.0.0.0", port);
     log_info("HTTP server stopped");
@@ -39,4 +47,8 @@ void WebServer::stop()
     if (server)
         server->stop();
     running = false;
+}
+
+void WebServer::add_proxy_port(const std::string& proxy_name, unsigned short port) {
+    proxy_ports[proxy_name] = port;
 }

--- a/webserver.hpp
+++ b/webserver.hpp
@@ -12,10 +12,12 @@ public:
     void run(); // blocks
     void stop();
     const char* module_name() const override;
+    void add_proxy_port(const std::string& proxy_name, unsigned short port);
 protected:
     unsigned short port;
     std::string content_dir;
     std::unique_ptr<httplib::Server> server;
     std::thread server_thread;
     std::atomic<bool> running;
+    std::map<std::string, unsigned short> proxy_ports;
 };

--- a/wwwroot/pdproxy/index.html
+++ b/wwwroot/pdproxy/index.html
@@ -442,10 +442,11 @@ is acknowledged in any modified source code
 <script src="https://unpkg.com/fzstd@0.1.1"></script>
 <script src="panel.js"></script>
 <script>
-const ws = new WebSocket('ws://localhost:4000');
+
 const statusLabel = document.getElementById('status');
 let lastMessageTime = null;
 let statusInterval = null;
+let ws = null;
 
 function formatDuration(ms) {
     const tenths = Math.floor((ms % 1000) / 100);
@@ -471,29 +472,43 @@ function updateStatusLabel() {
     }
 }
 
-ws.onopen = () => {
-    statusLabel.textContent = 'Connected';
-    statusInterval = setInterval(updateStatusLabel, 100); // update every 100ms for tenths
-};
-ws.onclose = () => {
-    statusLabel.textContent = 'Disconnected';
-    clearInterval(statusInterval);
-};
-ws.onerror = (e) => {
-    statusLabel.textContent = 'WebSocket error';
-    clearInterval(statusInterval);
-};
-ws.onmessage = (event) => {
-    try {
-        panel.state = JSON.parse(event.data);
-        lastMessageTime = Date.now();
-        updateLights();
-        updateStatusLabel();
-    } catch (e) {
-        statusLabel.textContent = 'Error parsing message';
-        console.error('Error parsing message:', e);
+fetch('/config.json')
+  .then(r => r.json())
+  .then(cfg => {
+// Extract the last non-empty directory part from the path
+    const pathParts = window.location.pathname.split('/').filter(Boolean);
+    let panelKey = pathParts[pathParts.length - 1];
+    // If the last part is a file (contains a dot), use the previous part
+    if (panelKey.includes('.')) {
+      panelKey = pathParts[pathParts.length - 2];
     }
-};
+    const port = cfg.proxyPorts[panelKey];
+    const wsUrl = `ws://${location.hostname}:${port}`;    ws = new WebSocket(wsUrl);
+
+    ws.onopen = () => {
+        statusLabel.textContent = 'Connected';
+        statusInterval = setInterval(updateStatusLabel, 100); // update every 100ms for tenths
+    };
+    ws.onclose = () => {
+        statusLabel.textContent = 'Disconnected';
+        clearInterval(statusInterval);
+    };
+    ws.onerror = (e) => {
+        statusLabel.textContent = 'WebSocket error';
+        clearInterval(statusInterval);
+    };
+    ws.onmessage = (event) => {
+        try {
+            panel.state = JSON.parse(event.data);
+            lastMessageTime = Date.now();
+            updateLights();
+            updateStatusLabel();
+        } catch (e) {
+            statusLabel.textContent = 'Error parsing message';
+            console.error('Error parsing message:', e);
+        }
+    };
+  });
 
 initialize();
 </script>

--- a/wwwroot/pdproxy/index.html
+++ b/wwwroot/pdproxy/index.html
@@ -465,9 +465,9 @@ function formatDuration(ms) {
 function updateStatusLabel() {
     if (lastMessageTime) {
         const ago = Date.now() - lastMessageTime;
-        statusLabel.textContent = `Connected, last update: ${formatDuration(ago)} ago`;
+        statusLabel.textContent = `Connected, time since last state: ${formatDuration(ago)}`;
     } else {
-        statusLabel.textContent = 'Connected, waiting for panel status...';
+        statusLabel.textContent = 'Connected, waiting for panel state...';
     }
 }
 


### PR DESCRIPTION
This will make the WebSocket address used by the virtual PDP panel dynamic in the following way:

- The hostname used is the one the PDP panel is fetched from
- The port number is retrieved from a config endpoint that is filled dynamically